### PR TITLE
setup: fix a typo in the url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ VERSION = '1.0'
 setup(
     name=NAME,
     version=VERSION,
-    url='http://sphinxcontrib-fulltox.readthedocs.org',
+    url='http://sphinxcontrib-fulltoc.readthedocs.org',
     license='Apache 2',
     author='Doug Hellmann',
     author_email='doug.hellmann@gmail.com',


### PR DESCRIPTION
When looking at the extension on PyPi, I noticed that the url was wrong.
