### PR TITLE
Blacklist pbr 3.1.1 from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pbr'],
+    setup_requires=['pbr!=3.1.1'],
     pbr=True)


### PR DESCRIPTION
Pbr release 3.1.1 is broken and causes problems with install via pip if
it is used, so make sure to prevent it being used.

Pbr 3.1.1 will result in the following error during a pip install:

  TypeError: super() argument 1 must be type, not None

fixes: #14