### PR TITLE
Use prune when rendering toctree to respect maxdepth

### DIFF
--- a/sphinxcontrib/fulltoc.py
+++ b/sphinxcontrib/fulltoc.py
@@ -43,7 +43,7 @@ def html_page_context(app, pagename, templatename, context, doctree):
     def make_toctree(collapse=True, maxdepth=-1, includehidden=True):
         return get_rendered_toctree(app.builder,
                                     pagename,
-                                    prune=False,
+                                    prune=True,
                                     collapse=collapse,
                                     )
     context['toctree'] = make_toctree


### PR DESCRIPTION
Note: I'm not well versed in the toctree creation here, but this change helped me get `maxdepth` be respected for the output. Perhaps this could be added as a configuration variable, but unsure how to do that (I can explore, but want to submit this change first to begin the conversation)

---
Prior to this, maxdepth was never respected and all headings within a document would be shown in the toctree. Now, we can have headings beyond the title in the document, that are not shown in the toctree (unless otherwise demanded through the use of `maxdepth`)
