### PR TITLE
rename master_doc to root_doc

### DIFF
--- a/sphinxcontrib/fulltoc.py
+++ b/sphinxcontrib/fulltoc.py
@@ -68,7 +68,7 @@ def build_full_toctree(builder, docname, prune, collapse):
     sub-document doctrees.
     """
     env = builder.env
-    doctree = env.get_doctree(env.config.master_doc)
+    doctree = env.get_doctree(env.config.root_doc)
     toctrees = []
     for toctreenode in doctree.traverse(addnodes.toctree):
         toctree = env.resolve_toctree(docname, builder, toctreenode,


### PR DESCRIPTION
Hi, this is my first pull request and its tiny. 
I know this project is not very active but I still use it gladly!(:

The variable master_doc was renamed to root_doc in sphinx 4.0.
See https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-root_doc

Changing master_doc to root_doc path issues in my project where the root_doc is not directly in project_root/docs but above.
